### PR TITLE
Improve forecast display layout

### DIFF
--- a/mobile-app/components/ForecastCard.js
+++ b/mobile-app/components/ForecastCard.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { convertTemperature, getWeatherIcon } from '../utils/formatting';
+
+export default function ForecastCard({ period, unit }) {
+  if (!period) return null;
+  const temp = convertTemperature(period.temperature, period.temperatureUnit, unit);
+  const icon = getWeatherIcon(period.shortForecast);
+  return (
+    <View style={styles.card}>
+      <View style={styles.row}>
+        <Text style={styles.period}>{period.name}</Text>
+        <Text style={styles.temp}>{temp}°{unit}</Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.icon}>{icon}</Text>
+        <Text style={styles.desc}>{period.shortForecast}</Text>
+      </View>
+      {period.windSpeed && (
+        <Text style={styles.detail}>Wind: {period.windSpeed} {period.windDirection}</Text>
+      )}
+      {period.probabilityOfPrecipitation && period.probabilityOfPrecipitation.value !== null && (
+        <Text style={styles.detail}>Precipitation: {period.probabilityOfPrecipitation.value}%</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  period: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    marginBottom: 4,
+  },
+  temp: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  icon: {
+    fontSize: 20,
+    marginRight: 6,
+  },
+  desc: {
+    flexShrink: 1,
+    color: '#444',
+  },
+  detail: {
+    color: '#555',
+    marginTop: 2,
+  },
+});

--- a/mobile-app/utils/formatting.js
+++ b/mobile-app/utils/formatting.js
@@ -1,0 +1,24 @@
+// Utility functions for formatting weather data
+
+export function convertTemperature(value, fromUnit, toUnit) {
+  if (value === undefined || value === null) return value;
+  if (fromUnit === toUnit) return Math.round(value);
+  if (fromUnit === 'F' && toUnit === 'C') {
+    return Math.round(((value - 32) * 5) / 9);
+  }
+  if (fromUnit === 'C' && toUnit === 'F') {
+    return Math.round((value * 9) / 5 + 32);
+  }
+  return Math.round(value);
+}
+
+export function getWeatherIcon(description = '') {
+  const text = description.toLowerCase();
+  if (/(sunny|clear)/.test(text)) return '☀️';
+  if (/(partly cloudy|mostly cloudy|cloudy|overcast)/.test(text)) return '⛅️';
+  if (/(rain|showers|drizzle)/.test(text)) return '🌧️';
+  if (/(thunder|storm)/.test(text)) return '⛈️';
+  if (/(snow|flurries|blizzard)/.test(text)) return '❄️';
+  if (/(fog|mist|haze)/.test(text)) return '🌫️';
+  return '🌡️';
+}


### PR DESCRIPTION
## Summary
- factor out a `ForecastCard` component
- share temp/icon helpers via new `formatting` utility
- use the new component for daily and hourly sections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a4c82adc883228603ad5c686175db