### PR TITLE
Add daily forecast bar chart with modal detail view

### DIFF
--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -42,6 +42,8 @@ import locations from './utils/locations';
 import { convertTemperature, getWeatherIcon } from './utils/formatting';
 import ForecastCard from './components/ForecastCard';
 import LocationDropdown from './components/LocationDropdown';
+import DailyBarChart from './components/DailyBarChart';
+import ForecastModal from './components/ForecastModal';
 
 export default function App() {
   // Selected location from our curated list.  Default to the first entry.
@@ -69,6 +71,7 @@ export default function App() {
   // onRefresh below.
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
+  const [detailVisible, setDetailVisible] = useState(false);
 
   // Monitor network connectivity.  The useNetInfo hook from
   // @react-native-community/netinfo returns an object with details about
@@ -516,9 +519,19 @@ export default function App() {
 
       {/* Daily forecast section */}
       <Text style={styles.heading}>Daily Forecast</Text>
-      {daily.map((p) => (
-        <ForecastCard key={p.number} period={p} unit={unit} />
-      ))}
+      <DailyBarChart periods={daily} unit={unit} />
+      <TouchableOpacity
+        style={styles.detailButton}
+        onPress={() => setDetailVisible(true)}
+      >
+        <Text style={styles.detailButtonText}>View Detailed</Text>
+      </TouchableOpacity>
+      <ForecastModal
+        visible={detailVisible}
+        onClose={() => setDetailVisible(false)}
+        periods={daily}
+        unit={unit}
+      />
 
       {/* Hourly forecast section */}
       <Text style={styles.heading}>Hourly Forecast (Next 12 Hours)</Text>
@@ -722,6 +735,19 @@ const styles = StyleSheet.create({
   clearButtonText: {
     color: '#333',
     fontSize: 12,
+  },
+
+  detailButton: {
+    marginTop: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: '#00704A',
+    borderRadius: 4,
+    alignSelf: 'center',
+  },
+  detailButtonText: {
+    color: '#fff',
+    fontWeight: 'bold',
   },
 
   // Banner shown at the top of the screen when there is no network

--- a/mobile-app/components/DailyBarChart.js
+++ b/mobile-app/components/DailyBarChart.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { convertTemperature, getWeatherIcon } from '../utils/formatting';
+
+export default function DailyBarChart({ periods = [], unit }) {
+  if (!periods.length) return null;
+
+  // Pair daytime and nighttime periods
+  const days = [];
+  for (let i = 0; i < periods.length; i += 2) {
+    const day = periods[i];
+    const night = periods[i + 1];
+    if (!day) continue;
+    const date = new Date(day.startTime).toLocaleDateString(undefined, {
+      weekday: 'short',
+    });
+    const high = convertTemperature(day.temperature, day.temperatureUnit, unit);
+    const low = night
+      ? convertTemperature(night.temperature, night.temperatureUnit, unit)
+      : null;
+    const emoji = getWeatherIcon(day.shortForecast);
+    days.push({ date, high, low, emoji });
+  }
+
+  const temps = days
+    .flatMap((d) => [d.high, d.low])
+    .filter((v) => v !== null);
+  const maxTemp = Math.max(...temps);
+  const minTemp = Math.min(...temps);
+  const range = maxTemp - minTemp || 1;
+  const chartHeight = 120;
+
+  return (
+    <View style={styles.chartContainer}>
+      {days.map((d, idx) => {
+        const highHeight = ((d.high - minTemp) / range) * chartHeight;
+        const lowHeight = d.low !== null ? ((d.low - minTemp) / range) * chartHeight : 0;
+        return (
+          <View key={idx} style={styles.group}>
+            <View style={styles.bars}>
+              <View style={[styles.highBar, { height: highHeight }]} />
+              <View style={[styles.lowBar, { height: lowHeight }]} />
+            </View>
+            <Text style={styles.label}>{d.date}</Text>
+            <Text>{d.emoji}</Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  chartContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-around',
+    marginBottom: 12,
+  },
+  group: {
+    alignItems: 'center',
+    marginHorizontal: 2,
+  },
+  bars: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    height: 120,
+  },
+  highBar: {
+    width: 8,
+    marginHorizontal: 1,
+    backgroundColor: '#E64A19',
+  },
+  lowBar: {
+    width: 8,
+    marginHorizontal: 1,
+    backgroundColor: '#1976D2',
+  },
+  label: {
+    fontSize: 12,
+  },
+});

--- a/mobile-app/components/ForecastModal.js
+++ b/mobile-app/components/ForecastModal.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Modal, View, TouchableOpacity, Text, StyleSheet, ScrollView } from 'react-native';
+import ForecastCard from './ForecastCard';
+
+export default function ForecastModal({ visible, onClose, periods = [], unit }) {
+  return (
+    <Modal visible={visible} transparent animationType="slide">
+      <View style={styles.overlay}>
+        <View style={styles.modal}>
+          <ScrollView>
+            {periods.map((p) => (
+              <ForecastCard key={p.number} period={p} unit={unit} />
+            ))}
+          </ScrollView>
+          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+            <Text style={styles.closeButtonText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  modal: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 16,
+    maxHeight: '80%',
+  },
+  closeButton: {
+    marginTop: 12,
+    alignSelf: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    backgroundColor: '#00704A',
+    borderRadius: 4,
+  },
+  closeButtonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
## Summary
- show daily forecast as a bar chart summarizing highs and lows
- allow opening a modal with the original card list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a56a523b483228f39d9b546cccef8