### PR TITLE
Apply React Native Paper dark theme

### DIFF
--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -6,10 +6,12 @@ import {
   Text,
   View,
   TouchableOpacity,
-  TextInput,
+  
   RefreshControl,
   Dimensions,
 } from 'react-native';
+
+import { Provider as PaperProvider, MD3DarkTheme, Button, TextInput as PaperInput } from 'react-native-paper';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
@@ -34,6 +36,14 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 const { width } = Dimensions.get('window');
 const Tab = createBottomTabNavigator();
+const theme = {
+  ...MD3DarkTheme,
+  colors: {
+    ...MD3DarkTheme.colors,
+    primary: '#bb86fc',
+    secondary: '#03dac6',
+  },
+};
 
 export default function App() {
   const [selectedLocation, setSelectedLocation] = useState(locations[0]);
@@ -311,7 +321,7 @@ export default function App() {
           <View style={styles.searchContainer}>
             <View style={styles.searchInputContainer}>
               <Text style={styles.searchIcon}>🔍</Text>
-              <TextInput
+              <PaperInput
                 style={styles.searchInput}
                 placeholder="Search for a location..."
                 placeholderTextColor="#8E8E93"
@@ -326,34 +336,32 @@ export default function App() {
                 </TouchableOpacity>
               )}
             </View>
-            <TouchableOpacity style={styles.searchButton} onPress={searchLocation}>
-              <Text style={styles.searchButtonText}>Search</Text>
-            </TouchableOpacity>
+            <Button mode="contained" style={styles.searchButton} onPress={searchLocation}>
+              Search
+            </Button>
           </View>
 
-          <TouchableOpacity style={styles.currentLocationButton} onPress={useCurrentLocation}>
-            <Text style={styles.locationIcon}>📍</Text>
-            <Text style={styles.currentLocationText}>Use Current Location</Text>
-          </TouchableOpacity>
+          <Button mode="outlined" style={styles.currentLocationButton} onPress={useCurrentLocation}>
+            📍 Use Current Location
+          </Button>
 
           {searchResults.length > 0 && (
             <View style={styles.searchResults}>
               {searchResults.map((res) => {
                 const isSelected = selectedLocation.id === res.id;
                 return (
-                  <TouchableOpacity
+                  <Button
                     key={res.id}
                     onPress={() => {
                       setSelectedLocation(res);
                       setSearchResults([]);
                       setSearchQuery(res.name);
                     }}
-                    style={[styles.searchResultItem, isSelected && styles.selectedSearchResult]}
+                    mode={isSelected ? 'contained' : 'outlined'}
+                    style={styles.searchResultItem}
                   >
-                    <Text style={[styles.searchResultText, isSelected && styles.selectedSearchResultText]}>
-                      {res.name}
-                    </Text>
-                  </TouchableOpacity>
+                    {res.name}
+                  </Button>
                 );
               })}
             </View>
@@ -363,15 +371,14 @@ export default function App() {
             {['F', 'C'].map((u) => {
               const selected = unit === u;
               return (
-                <TouchableOpacity
+                <Button
                   key={u}
                   onPress={() => setUnit(u)}
-                  style={[styles.unitButton, selected && styles.selectedUnitButton]}
+                  mode={selected ? 'contained' : 'outlined'}
+                  style={styles.unitButton}
                 >
-                  <Text style={[styles.unitButtonText, selected && styles.selectedUnitButtonText]}>
-                    °{u}
-                  </Text>
-                </TouchableOpacity>
+                  °{u}
+                </Button>
               );
             })}
           </View>
@@ -404,10 +411,9 @@ export default function App() {
                   </Text>
                 </View>
               ))}
-              <TouchableOpacity style={styles.alertButton} onPress={notifyAlerts}>
-                <Text style={styles.alertButtonIcon}>🔔</Text>
-                <Text style={styles.alertButtonText}>Get Alert Notifications</Text>
-              </TouchableOpacity>
+              <Button mode="contained" style={styles.alertButton} onPress={notifyAlerts}>
+                🔔 Get Alert Notifications
+              </Button>
             </View>
           </View>
         )}
@@ -424,10 +430,9 @@ export default function App() {
               <HourlyBarChart periods={hourly} unit={unit} />
             )}
           </View>
-          <TouchableOpacity style={styles.viewDetailButton} onPress={() => setDetailVisibleLocal(true)}>
-            <Text style={styles.viewDetailButtonText}>View Detailed Forecast</Text>
-            <Text style={styles.viewDetailButtonIcon}>→</Text>
-          </TouchableOpacity>
+          <Button mode="outlined" style={styles.viewDetailButton} onPress={() => setDetailVisibleLocal(true)}>
+            View Detailed Forecast →
+          </Button>
         </View>
 
         <ForecastModal
@@ -447,12 +452,9 @@ export default function App() {
           <Text style={styles.errorIcon}>⚠️</Text>
           <Text style={styles.errorTitle}>Weather Unavailable</Text>
           <Text style={styles.errorMessage}>{error}</Text>
-          <TouchableOpacity 
-            style={styles.retryButton} 
-            onPress={() => setRefreshTrigger(prev => prev + 1)}
-          >
-            <Text style={styles.retryButtonText}>Try Again</Text>
-          </TouchableOpacity>
+          <Button mode="contained" style={styles.retryButton} onPress={() => setRefreshTrigger(prev => prev + 1)}>
+            Try Again
+          </Button>
         </View>
       </View>
     );
@@ -470,396 +472,64 @@ export default function App() {
   }
 
   return (
-    <NavigationContainer>
-      <Tab.Navigator screenOptions={{ headerShown: false }}>
-        <Tab.Screen
-          name="Daily"
-          options={{ tabBarIcon: () => <Text>📅</Text> }}
-        >{() => <ForecastView mode="daily" />}</Tab.Screen>
-        <Tab.Screen
-          name="Hourly"
-          options={{ tabBarIcon: () => <Text>⏰</Text> }}
-        >{() => <ForecastView mode="hourly" />}</Tab.Screen>
-      </Tab.Navigator>
-    </NavigationContainer>
+    <PaperProvider theme={theme}>
+      <NavigationContainer theme={theme}>
+        <Tab.Navigator screenOptions={{ headerShown: false }}>
+          <Tab.Screen
+            name="Daily"
+            options={{ tabBarIcon: () => <Text>📅</Text> }}
+          >{() => <ForecastView mode="daily" />}</Tab.Screen>
+          <Tab.Screen
+            name="Hourly"
+            options={{ tabBarIcon: () => <Text>⏰</Text> }}
+          >{() => <ForecastView mode="hourly" />}</Tab.Screen>
+        </Tab.Navigator>
+      </NavigationContainer>
+    </PaperProvider>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#F8F9FA',
-  },
-  scrollContainer: {
-    paddingBottom: 30,
-  },
-  loadingContainer: {
-    flex: 1,
-    backgroundColor: '#F8F9FA',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  loadingContent: {
-    alignItems: 'center',
-    padding: 40,
-  },
-  loadingText: {
-    marginTop: 16,
-    fontSize: 16,
-    color: '#8E8E93',
-    fontWeight: '500',
-  },
-  errorContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 40,
-    backgroundColor: '#F8F9FA',
-  },
-  errorIcon: {
-    fontSize: 48,
-    marginBottom: 16,
-  },
-  errorTitle: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: '#1C1C1E',
-    marginBottom: 8,
-  },
-  errorMessage: {
-    fontSize: 16,
-    color: '#8E8E93',
-    textAlign: 'center',
-    marginBottom: 24,
-    lineHeight: 22,
-  },
-  retryButton: {
-    backgroundColor: '#4A90E2',
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 25,
-  },
-  retryButtonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  offlineBanner: {
-    backgroundColor: '#FFE4B5',
-    borderLeftWidth: 4,
-    borderLeftColor: '#FF8C00',
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    marginHorizontal: 16,
-    marginTop: 16,
-    borderRadius: 8,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  offlineIcon: {
-    fontSize: 20,
-    marginRight: 8,
-  },
-  offlineText: {
-    color: '#B8860B',
-    fontSize: 14,
-    fontWeight: '500',
-  },
-  heroSection: {
-    marginHorizontal: 16,
-    marginTop: 16,
-    marginBottom: 24,
-    borderRadius: 20,
-    overflow: 'hidden',
-    backgroundColor: '#4A90E2',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 5,
-  },
-  heroContent: {
-    padding: 32,
-    alignItems: 'center',
-  },
-  locationName: {
-    fontSize: 18,
-    color: '#FFFFFF',
-    fontWeight: '600',
-    marginBottom: 8,
-    textAlign: 'center',
-  },
-  currentTemp: {
-    fontSize: 64,
-    color: '#FFFFFF',
-    fontWeight: '200',
-    marginBottom: 4,
-  },
-  weatherCondition: {
-    fontSize: 18,
-    color: '#E6F2FF',
-    fontWeight: '500',
-    marginBottom: 8,
-  },
-  weatherIcon: {
-    fontSize: 32,
-  },
-  section: {
-    marginHorizontal: 16,
-    marginBottom: 24,
-  },
-  sectionHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  sectionIcon: {
-    fontSize: 24,
-    marginRight: 8,
-  },
-  sectionTitle: {
-    fontSize: 22,
-    fontWeight: 'bold',
-    color: '#1C1C1E',
-  },
-  searchContainer: {
-    marginBottom: 16,
-  },
-  searchInputContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 4,
-    marginBottom: 12,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  searchIcon: {
-    fontSize: 16,
-    color: '#8E8E93',
-    marginRight: 8,
-  },
-  searchInput: {
-    flex: 1,
-    fontSize: 16,
-    color: '#1C1C1E',
-    paddingVertical: 12,
-  },
-  clearButton: {
-    padding: 4,
-  },
-  clearIcon: {
-    fontSize: 16,
-    color: '#8E8E93',
-  },
-  searchButton: {
-    backgroundColor: '#4A90E2',
-    paddingVertical: 14,
-    paddingHorizontal: 24,
-    borderRadius: 12,
-    alignItems: 'center',
-    shadowColor: '#4A90E2',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  searchButtonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  currentLocationButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#FFFFFF',
-    paddingVertical: 14,
-    paddingHorizontal: 16,
-    borderRadius: 12,
-    marginBottom: 16,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  locationIcon: {
-    fontSize: 20,
-    marginRight: 8,
-  },
-  currentLocationText: {
-    color: '#4A90E2',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  searchResults: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    marginBottom: 16,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
-    overflow: 'hidden',
-  },
-  searchResultItem: {
-    paddingVertical: 16,
-    paddingHorizontal: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: '#F2F2F7',
-  },
-  selectedSearchResult: {
-    backgroundColor: '#4A90E2',
-  },
-  searchResultText: {
-    fontSize: 16,
-    color: '#1C1C1E',
-  },
-  selectedSearchResultText: {
-    color: '#FFFFFF',
-  },
-  unitToggle: {
-    flexDirection: 'row',
-    backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    padding: 4,
-    marginBottom: 16,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
-    alignSelf: 'flex-end',
-  },
-  unitButton: {
-    paddingVertical: 8,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-  },
-  selectedUnitButton: {
-    backgroundColor: '#4A90E2',
-  },
-  unitButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#8E8E93',
-  },
-  selectedUnitButtonText: {
-    color: '#FFFFFF',
-  },
-  alertsContainer: {
-    backgroundColor: '#FFF8E1',
-    borderRadius: 16,
-    padding: 20,
-    borderLeftWidth: 4,
-    borderLeftColor: '#FF9500',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  alertsHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  alertsIcon: {
-    fontSize: 24,
-    marginRight: 8,
-  },
-  alertCard: {
-    backgroundColor: '#FFFFFF',
-    padding: 16,
-    borderRadius: 12,
-    marginBottom: 12,
-    borderLeftWidth: 3,
-    borderLeftColor: '#FF9500',
-  },
-  alertTitle: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: '#1C1C1E',
-    marginBottom: 8,
-  },
-  alertDescription: {
-    fontSize: 14,
-    color: '#3C3C43',
-    lineHeight: 20,
-  },
-  alertButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#FF9500',
-    paddingVertical: 14,
-    paddingHorizontal: 20,
-    borderRadius: 12,
-    alignSelf: 'flex-start',
-    shadowColor: '#FF9500',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  alertButtonIcon: {
-    fontSize: 16,
-    marginRight: 8,
-  },
-  alertButtonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  chartContainer: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 16,
-    padding: 20,
-    marginBottom: 16,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    elevation: 5,
-  },
-  viewDetailButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#4A90E2',
-    paddingVertical: 14,
-    paddingHorizontal: 24,
-    borderRadius: 12,
-    shadowColor: '#4A90E2',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  viewDetailButtonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
-    marginRight: 8,
-  },
-  viewDetailButtonIcon: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: 'bold',
-  },
-  hourlyContainer: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 16,
-    padding: 16,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    elevation: 5,
-  },
+  container: { flex: 1, backgroundColor: '#121212' },
+  scrollContainer: { paddingBottom: 30 },
+  loadingContainer: { flex: 1, backgroundColor: '#121212', justifyContent: 'center', alignItems: 'center' },
+  loadingContent: { alignItems: 'center', padding: 40 },
+  loadingText: { marginTop: 16, fontSize: 16, color: '#ffffff' },
+  errorContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 40, backgroundColor: '#121212' },
+  errorTitle: { fontSize: 24, color: '#ffffff', marginBottom: 8, fontWeight: 'bold' },
+  errorMessage: { fontSize: 16, color: '#cccccc', textAlign: 'center', marginBottom: 24 },
+  retryButton: { marginTop: 12, alignSelf: 'center' },
+  offlineBanner: { backgroundColor: '#333333', padding: 12, margin: 16, borderRadius: 8, flexDirection: 'row', alignItems: 'center' },
+  offlineIcon: { fontSize: 20, marginRight: 8, color: '#ffffff' },
+  offlineText: { color: '#ffffff' },
+  heroSection: { margin: 16, borderRadius: 20, backgroundColor: '#333333', padding: 32, alignItems: 'center' },
+  locationName: { fontSize: 18, color: '#ffffff', marginBottom: 8, textAlign: 'center' },
+  currentTemp: { fontSize: 64, color: '#ffffff', marginBottom: 4 },
+  weatherCondition: { fontSize: 18, color: '#ffffff', marginBottom: 8 },
+  weatherIcon: { fontSize: 32 },
+  section: { marginHorizontal: 16, marginBottom: 24 },
+  sectionHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 16 },
+  sectionIcon: { fontSize: 24, marginRight: 8 },
+  sectionTitle: { fontSize: 22, color: '#ffffff', fontWeight: 'bold' },
+  searchContainer: { marginBottom: 16 },
+  searchInputContainer: { flexDirection: 'row', alignItems: 'center' },
+  searchIcon: { fontSize: 16, color: '#cccccc', marginRight: 8 },
+  searchInput: { flex: 1, backgroundColor: '#1e1e1e' },
+  clearButton: { padding: 4 },
+  clearIcon: { fontSize: 16, color: '#cccccc' },
+  searchButton: { marginTop: 8 },
+  currentLocationButton: { marginBottom: 16 },
+  searchResults: { backgroundColor: '#1e1e1e', borderRadius: 12, marginBottom: 16 },
+  searchResultItem: { marginVertical: 4 },
+  unitToggle: { flexDirection: 'row', marginBottom: 16, alignSelf: 'flex-end' },
+  unitButton: { marginLeft: 4 },
+  alertsContainer: { backgroundColor: '#1e1e1e', borderRadius: 16, padding: 20 },
+  alertsHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 16 },
+  alertsIcon: { fontSize: 24, marginRight: 8, color: '#ffffff' },
+  alertCard: { backgroundColor: '#333333', padding: 16, borderRadius: 12, marginBottom: 12 },
+  alertTitle: { fontSize: 16, color: '#ffffff', marginBottom: 8, fontWeight: 'bold' },
+  alertDescription: { fontSize: 14, color: '#cccccc' },
+  alertButton: { marginTop: 8 },
+  chartContainer: { backgroundColor: '#1e1e1e', borderRadius: 16, padding: 20, marginBottom: 16 },
+  viewDetailButton: { alignSelf: 'center', marginTop: 8 },
 });

--- a/mobile-app/components/DailyBarChart.js
+++ b/mobile-app/components/DailyBarChart.js
@@ -76,10 +76,10 @@ const styles = StyleSheet.create({
   lowBar: {
     width: 10,
     marginHorizontal: 1,
-    backgroundColor: '#4A90E2',
+    backgroundColor: '#bb86fc',
   },
   label: {
     fontSize: 12,
-    color: '#333',
+    color: '#FFFFFF',
   },
 });

--- a/mobile-app/components/ForecastCard.js
+++ b/mobile-app/components/ForecastCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { Card, Text } from 'react-native-paper';
 import { convertTemperature, getWeatherIcon } from '../utils/formatting';
 
 export default function ForecastCard({ period, unit }) {
@@ -7,52 +8,37 @@ export default function ForecastCard({ period, unit }) {
   const temp = convertTemperature(period.temperature, period.temperatureUnit, unit);
   const icon = getWeatherIcon(period.shortForecast);
   return (
-    <View style={styles.card}>
-      <View style={styles.row}>
+    <Card style={styles.card} mode="contained">
+      <Card.Content>
         <Text style={styles.period}>{period.name}</Text>
         <Text style={styles.temp}>{temp}°{unit}</Text>
-      </View>
-      <View style={styles.row}>
         <Text style={styles.icon}>{icon}</Text>
         <Text style={styles.desc}>{period.shortForecast}</Text>
-      </View>
-      {period.windSpeed && (
-        <Text style={styles.detail}>Wind: {period.windSpeed} {period.windDirection}</Text>
-      )}
-      {period.probabilityOfPrecipitation && period.probabilityOfPrecipitation.value !== null && (
-        <Text style={styles.detail}>Precipitation: {period.probabilityOfPrecipitation.value}%</Text>
-      )}
-    </View>
+        {period.windSpeed && (
+          <Text style={styles.detail}>Wind: {period.windSpeed} {period.windDirection}</Text>
+        )}
+        {period.probabilityOfPrecipitation && period.probabilityOfPrecipitation.value !== null && (
+          <Text style={styles.detail}>Precipitation: {period.probabilityOfPrecipitation.value}%</Text>
+        )}
+      </Card.Content>
+    </Card>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
-    backgroundColor: '#FFFFFF',
-    padding: 16,
-    borderRadius: 12,
     marginBottom: 12,
-    shadowColor: '#000',
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 5,
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
   },
   period: {
     fontWeight: '600',
     fontSize: 16,
     marginBottom: 4,
-    color: '#1C1C1E',
+    color: '#FFFFFF',
   },
   temp: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#1C1C1E',
+    color: '#FFFFFF',
   },
   icon: {
     fontSize: 20,
@@ -60,10 +46,10 @@ const styles = StyleSheet.create({
   },
   desc: {
     flexShrink: 1,
-    color: '#3C3C43',
+    color: '#CCCCCC',
   },
   detail: {
-    color: '#3C3C43',
+    color: '#CCCCCC',
     marginTop: 2,
   },
 });

--- a/mobile-app/components/ForecastModal.js
+++ b/mobile-app/components/ForecastModal.js
@@ -1,49 +1,36 @@
 import React from 'react';
-import { Modal, View, TouchableOpacity, Text, StyleSheet, ScrollView } from 'react-native';
+import { View, StyleSheet, ScrollView } from 'react-native';
+import { Modal, Portal, Button, Text } from 'react-native-paper';
 import ForecastCard from './ForecastCard';
 
 export default function ForecastModal({ visible, onClose, periods = [], unit }) {
   return (
-    <Modal visible={visible} transparent animationType="slide">
-      <View style={styles.overlay}>
-        <View style={styles.modal}>
-          <ScrollView>
-            {periods.map((p) => (
-              <ForecastCard key={p.number} period={p} unit={unit} />
-            ))}
-          </ScrollView>
-          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
-            <Text style={styles.closeButtonText}>Close</Text>
-          </TouchableOpacity>
-        </View>
-      </View>
-    </Modal>
+    <Portal>
+      <Modal visible={visible} onDismiss={onClose} contentContainerStyle={styles.modal}>
+        <ScrollView>
+          {periods.map((p) => (
+            <ForecastCard key={p.number} period={p} unit={unit} />
+          ))}
+        </ScrollView>
+        <Button mode="contained" style={styles.closeButton} onPress={onClose}>
+          Close
+        </Button>
+      </Modal>
+    </Portal>
   );
 }
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.3)',
-    justifyContent: 'center',
-    padding: 20,
-  },
   modal: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: '#1e1e1e',
     borderRadius: 16,
     padding: 20,
+    margin: 20,
     maxHeight: '80%',
   },
   closeButton: {
     marginTop: 12,
     alignSelf: 'center',
-    paddingVertical: 12,
-    paddingHorizontal: 24,
-    backgroundColor: '#4A90E2',
-    borderRadius: 12,
   },
-  closeButtonText: {
-    color: '#FFFFFF',
-    fontWeight: '600',
-  },
+  closeButtonText: {},
 });

--- a/mobile-app/components/HourlyBarChart.js
+++ b/mobile-app/components/HourlyBarChart.js
@@ -41,10 +41,10 @@ const styles = StyleSheet.create({
   },
   bar: {
     width: 6,
-    backgroundColor: '#4A90E2',
+    backgroundColor: '#bb86fc',
   },
   label: {
     fontSize: 10,
-    color: '#333',
+    color: '#FFFFFF',
   },
 });

--- a/mobile-app/components/LocationDropdown.js
+++ b/mobile-app/components/LocationDropdown.js
@@ -1,13 +1,6 @@
 import React, { useState } from 'react';
-import {
-  Modal,
-  View,
-  Text,
-  TouchableOpacity,
-  StyleSheet,
-  FlatList,
-  Switch,
-} from 'react-native';
+import { View, StyleSheet, FlatList } from 'react-native';
+import { Modal, Portal, Button, Switch, Text, Card } from 'react-native-paper';
 
 export default function LocationDropdown({
   locations,
@@ -32,55 +25,49 @@ export default function LocationDropdown({
     const isFav = favorites.includes(item.id);
     return (
       <View style={styles.row}>
-        <TouchableOpacity
-          style={[styles.item, isSelected && styles.selectedItem]}
+        <Button
+          mode={isSelected ? 'contained' : 'outlined'}
+          style={styles.item}
           onPress={() => {
             onSelect(item);
             setVisible(false);
           }}
         >
-          <Text style={[styles.itemText, isSelected && styles.selectedItemText]}>
-            {item.name}
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.starButton}
+          {item.name}
+        </Button>
+        <Button
+          mode="text"
+          compact
           onPress={() => onToggleFavorite(item.id)}
+          textColor={isFav ? '#E2A72E' : undefined}
         >
-          <Text style={isFav ? styles.favStar : styles.star}>
-            {isFav ? '★' : '☆'}
-          </Text>
-        </TouchableOpacity>
+          {isFav ? '★' : '☆'}
+        </Button>
       </View>
     );
   };
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity style={styles.selector} onPress={() => setVisible(true)}>
-        <Text style={styles.selectorText}>{selectedLocation.name}</Text>
-      </TouchableOpacity>
-      <Modal visible={visible} transparent animationType="slide">
-        <View style={styles.overlay}>
-          <View style={styles.modal}>
-            <View style={styles.filterRow}>
-              <Text style={styles.filterLabel}>Favorites only</Text>
-              <Switch value={showFavs} onValueChange={setShowFavs} />
-            </View>
-            <FlatList
-              data={data}
-              keyExtractor={(item) => item.id}
-              renderItem={renderItem}
-            />
-            <TouchableOpacity
-              style={styles.closeButton}
-              onPress={() => setVisible(false)}
-            >
-              <Text style={styles.closeButtonText}>Close</Text>
-            </TouchableOpacity>
+      <Button mode="outlined" onPress={() => setVisible(true)}>
+        {selectedLocation.name}
+      </Button>
+      <Portal>
+        <Modal visible={visible} onDismiss={() => setVisible(false)} contentContainerStyle={styles.modal}>
+          <View style={styles.filterRow}>
+            <Text style={styles.filterLabel}>Favorites only</Text>
+            <Switch value={showFavs} onValueChange={setShowFavs} />
           </View>
-        </View>
-      </Modal>
+          <FlatList
+            data={data}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+          />
+          <Button mode="contained" style={styles.closeButton} onPress={() => setVisible(false)}>
+            Close
+          </Button>
+        </Modal>
+      </Portal>
     </View>
   );
 }
@@ -89,28 +76,11 @@ const styles = StyleSheet.create({
   container: {
     marginBottom: 20,
   },
-  selector: {
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderWidth: 1,
-    borderColor: '#ccc',
-    borderRadius: 12,
-    backgroundColor: '#FFFFFF',
-  },
-  selectorText: {
-    fontWeight: '600',
-    color: '#1C1C1E',
-  },
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.3)',
-    justifyContent: 'center',
-    padding: 20,
-  },
   modal: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: '#1e1e1e',
     borderRadius: 16,
     padding: 20,
+    margin: 20,
     maxHeight: '80%',
   },
   filterRow: {
@@ -121,7 +91,7 @@ const styles = StyleSheet.create({
   },
   filterLabel: {
     fontWeight: 'bold',
-    color: '#333',
+    color: '#FFFFFF',
   },
   row: {
     flexDirection: 'row',
@@ -130,45 +100,11 @@ const styles = StyleSheet.create({
   },
   item: {
     flex: 1,
-    paddingVertical: 6,
-    paddingHorizontal: 8,
-    borderWidth: 1,
-    borderColor: '#ccc',
-    borderRadius: 4,
-    backgroundColor: '#f9f9f9',
-  },
-  selectedItem: {
-    backgroundColor: '#4A90E2',
-    borderColor: '#4A90E2',
-  },
-  itemText: {
-    color: '#1C1C1E',
-  },
-  selectedItemText: {
-    color: '#FFFFFF',
-  },
-  starButton: {
-    marginLeft: 8,
-    padding: 4,
-  },
-  star: {
-    fontSize: 18,
-    color: '#bbb',
-  },
-  favStar: {
-    fontSize: 18,
-    color: '#E2A72E',
+    marginVertical: 4,
+    marginRight: 8,
   },
   closeButton: {
     marginTop: 12,
-    paddingVertical: 12,
     alignSelf: 'center',
-    paddingHorizontal: 24,
-    backgroundColor: '#4A90E2',
-    borderRadius: 12,
-  },
-  closeButtonText: {
-    color: '#FFFFFF',
-    fontWeight: '600',
   },
 });

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -19,9 +19,10 @@
         "galio-framework": "^0.8.0",
         "react": "19.0.0",
         "react-native": "0.79.5",
-        "react-native-gesture-handler": "^2.27.2",
-        "react-native-safe-area-context": "^5.5.2",
-        "react-native-screens": "^4.13.1"
+        "react-native-gesture-handler": "2.24.0",
+        "react-native-paper": "^5.14.5",
+        "react-native-safe-area-context": "5.4.0",
+        "react-native-screens": "4.11.1"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -1591,6 +1592,28 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.9.tgz",
+      "integrity": "sha512-tTQ0uDSCL0ypeMa8T/E9wAZRGKWj8kXP7+6RYgPTfOPs9N07C9xM8P02GJ3feETap4Ux5S69D9nteq9mEj86NA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider/node_modules/deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -7270,9 +7293,9 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.27.2",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.27.2.tgz",
-      "integrity": "sha512-+kNaY2m7uQu5+5ls8os6z92DTk9expsEAYsaPv30n08mrqX2r64G8iVGDwNWzZcId54+P7RlDnhyszTql0sQ0w==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.24.0.tgz",
+      "integrity": "sha512-ZdWyOd1C8axKJHIfYxjJKCcxjWEpUtUWgTOVY2wynbiveSQDm8X/PDyAKXSer/GOtIpjudUbACOndZXCN3vHsw==",
       "license": "MIT",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
@@ -7294,10 +7317,55 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-paper": {
+      "version": "5.14.5",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-5.14.5.tgz",
+      "integrity": "sha512-eaIH5bUQjJ/mYm4AkI6caaiyc7BcHDwX6CqNDi6RIxfxfWxROsHpll1oBuwn/cFvknvA8uEAkqLk/vzVihI3AQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "docs"
+      ],
+      "dependencies": {
+        "@callstack/react-theme-provider": "^3.0.9",
+        "color": "^3.1.2",
+        "use-latest-callback": "^0.2.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": "*"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
     "node_modules/react-native-safe-area-context": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.5.2.tgz",
-      "integrity": "sha512-t4YVbHa9uAGf+pHMabGrb0uHrD5ogAusSu842oikJ3YKXcYp6iB4PTGl0EZNkUIR3pCnw/CXKn42OCfhsS0JIw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
+      "integrity": "sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -7305,13 +7373,13 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.13.1.tgz",
-      "integrity": "sha512-EESsMAtyzYcL3gpAI2NKKiIo+Ew0fnX4P4b3Zy/+MTc6SJIo3foJbZwdIWd/SUBswOf7IYCvWBppg+D8tbwnsw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.11.1.tgz",
+      "integrity": "sha512-F0zOzRVa3ptZfLpD0J8ROdo+y1fEPw+VBFq1MTY/iyDu08al7qFUO5hLMd+EYMda5VXGaTFCa8q7bOppUszhJw==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",
-        "react-native-is-edge-to-edge": "^1.2.1",
+        "react-native-is-edge-to-edge": "^1.1.7",
         "warn-once": "^0.1.0"
       },
       "peerDependencies": {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -22,6 +22,7 @@
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-gesture-handler": "2.24.0",
+    "react-native-paper": "^5.14.5",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.11.1"
   }


### PR DESCRIPTION
## Summary
- add `react-native-paper`
- refactor ForecastCard, LocationDropdown, ForecastModal and charts to use Paper components
- wrap `App` with PaperProvider and apply MD3 dark theme
- simplify styles for cohesive dark UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b72206e908322a053f14b9a98e2e1